### PR TITLE
Describe enable_jtag_gpio for config.txt

### DIFF
--- a/configuration/config-txt/gpio.md
+++ b/configuration/config-txt/gpio.md
@@ -41,3 +41,16 @@ utilities like `raspi-gpio`.
 
 Note also that there is a delay of a few seconds between power being applied and the changes taking effect — longer
 if booting over the network or from a USB mass storage device.
+
+## `enable_jtag_gpio`
+
+Setting `enable_jtag_gpio=1` selects Alt4 mode for GPIO pins 22-27, thus enabling JTAG interface for the ARM CPU.
+
+| Pin #  | Function |
+| ------ | -------- |
+| GPIO22 | ARM_TRST |
+| GPIO23 | ARM_RTCK |
+| GPIO24 | ARM_TDO  |
+| GPIO25 | ARM_TCK  |
+| GPIO26 | ARM_TDI  |
+| GPIO27 | ARM_TMS  |


### PR DESCRIPTION
I've seen this option mentioned in a few blog posts and Github issues, but not documented.
I **guess** this is just a shortcut for `gpio=22-27=a4` (but maybe there's more to this - please correct me if I'm wrong).

Maybe someone with more experience could comment. Thanks!

References:
* https://github.com/raspberrypi/firmware/issues/639
* https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2835/BCM2835-ARM-Peripherals.pdf (section 6.2 - Alternative Function Assignments)
